### PR TITLE
Add support for executing external command on detected fileName string

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -92,7 +92,7 @@ module.exports =
         return filePath
 
     # Execute external command defined in config
-    if atom.config.get(PACKAGE_NAME + '.customSearchCommand')
+    if atom.config.get('open-this.customSearchCommand')
       for dir in atom.project.getPaths()
         try
           if filePath = execSync ['FILENAME=' + fileName,


### PR DESCRIPTION
This feature is needed to support various external resolvers.

For instance, our client-side stack supports requiring files by namespace, e.g. `require('app:ui.field.input’)`. This syntax is specific to our project with paths defined in a project config file. We have a command-line tool which can resolve those namespaced paths to real paths and to use it I needed to add this custom functionality in open-this.